### PR TITLE
Improve artwork modal controls and shared counter logic

### DIFF
--- a/_layouts/artwork.html
+++ b/_layouts/artwork.html
@@ -54,8 +54,9 @@ layout: default
 
 <!-- Modal for Enlarged Image Display -->
 <div id="modal" class="modal">
-  <span class="modal-prev" id="modal-prev" onclick="showPrevImage()">&#10094;</span>
-  <span class="modal-next" id="modal-next" onclick="showNextImage()">&#10095;</span>
-  <span class="modal-close" id="modal-close" onclick="closeModal()">&times;</span>
+  <div id="modal-counter" class="modal-counter"></div>
+  <button type="button" class="modal-close" id="modal-close" onclick="closeModal()" aria-label="Close image viewer">&times;</button>
+  <button type="button" class="modal-prev" id="modal-prev" onclick="showPrevImage()" aria-label="Previous image">&#10094;</button>
+  <button type="button" class="modal-next" id="modal-next" onclick="showNextImage()" aria-label="Next image">&#10095;</button>
   <img class="modal-content" id="modal-img" src="" alt="Enlarged Artwork">
 </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -292,9 +292,24 @@ button:hover, .preview-btn:hover {
   top: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0,0,0,0.8);
+  background-color: rgba(0,0,0,0.4);
   justify-content: center;
   align-items: center;
+  padding: 20px;
+}
+
+.modal-counter {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 0.95rem;
+  display: none;
+  z-index: 10001;
+  pointer-events: none;
 }
 
 .modal-content {
@@ -304,20 +319,37 @@ button:hover, .preview-btn:hover {
   margin: auto;
 }
 
-/* Modal Navigation Buttons (positioned at the bottom) */
+/* Modal controls */
+.modal-close {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: none;
+  font-size: 2rem;
+  line-height: 1;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  z-index: 10001;
+}
+
 .modal-prev,
 .modal-next {
   position: absolute;
-  bottom: 20px;
-  font-size: 50px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 2.2rem;
   font-weight: bold;
   cursor: pointer;
   user-select: none;
-  padding: 20px 40px;
-  background: #f4f4f9;
-  color: #000;
-  border: 1px solid #ccc;
-  border-radius: 5px;
+  padding: 12px 18px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: none;
+  border-radius: 50px;
+  z-index: 10001;
 }
 
 .modal-prev {
@@ -385,8 +417,25 @@ button:hover, .preview-btn:hover {
   }
   .modal-prev,
   .modal-next {
-    font-size: 30px;
-    padding: 10px 20px;
-    bottom: 10px;
+    font-size: 1.8rem;
+    padding: 10px 14px;
+  }
+  .modal-prev {
+    left: 10px;
+  }
+  .modal-next {
+    right: 10px;
+  }
+  .modal-counter {
+    top: 12px;
+    left: 12px;
+    font-size: 0.85rem;
+    padding: 4px 10px;
+  }
+  .modal-close {
+    top: 12px;
+    right: 12px;
+    font-size: 1.6rem;
+    padding: 6px 10px;
   }
 }


### PR DESCRIPTION
## Summary
- add dedicated counter and navigation controls to the artwork modal layout
- restyle the modal overlay so controls sit in the corners and stay visible on small screens
- consolidate modal navigation logic across artwork, set, and reference galleries while keeping the counter in sync

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e1efa028288323a8a9041d1bb8a5c4