### PR TITLE
Enable zoom and pan in artwork modal

### DIFF
--- a/_layouts/artwork.html
+++ b/_layouts/artwork.html
@@ -58,5 +58,7 @@ layout: default
   <button type="button" class="modal-close" id="modal-close" onclick="closeModal()" aria-label="Close image viewer">&times;</button>
   <button type="button" class="modal-prev" id="modal-prev" onclick="showPrevImage()" aria-label="Previous image">&#10094;</button>
   <button type="button" class="modal-next" id="modal-next" onclick="showNextImage()" aria-label="Next image">&#10095;</button>
-  <img class="modal-content" id="modal-img" src="" alt="Enlarged Artwork">
+  <div id="modal-image-wrapper">
+    <img class="modal-content" id="modal-img" src="" alt="Enlarged Artwork">
+  </div>
 </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -312,11 +312,28 @@ button:hover, .preview-btn:hover {
   pointer-events: none;
 }
 
-.modal-content {
-  display: block;
+#modal-image-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   max-width: 95%;
   max-height: 95%;
-  margin: auto;
+  overflow: hidden;
+  cursor: grab;
+  touch-action: none;
+}
+
+#modal-image-wrapper.is-grabbing {
+  cursor: grabbing;
+}
+
+.modal-content {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  margin: 0;
+  transition: transform 0.1s ease-out;
+  will-change: transform;
 }
 
 /* Modal controls */


### PR DESCRIPTION
## Summary
- wrap the modal artwork image in a transformable container to support new interactions
- style the modal wrapper for hidden overflow and cursor feedback during panning
- add zoom, pan, and reset handlers that keep modal transforms in sync across image loads and close events

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f1705a208323a2191c4ba3bc161f