### PR TITLE
Add pan and zoom support to artwork modal

### DIFF
--- a/_layouts/artwork.html
+++ b/_layouts/artwork.html
@@ -59,6 +59,8 @@ layout: default
   <button type="button" class="modal-prev" id="modal-prev" onclick="showPrevImage()" aria-label="Previous image">&#10094;</button>
   <button type="button" class="modal-next" id="modal-next" onclick="showNextImage()" aria-label="Next image">&#10095;</button>
   <div id="modal-image-wrapper">
-    <img class="modal-content" id="modal-img" src="" alt="Enlarged Artwork">
+    <div id="modal-image-container">
+      <img class="modal-content" id="modal-img" src="" alt="Enlarged Artwork" draggable="false">
+    </div>
   </div>
 </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -316,14 +316,27 @@ button:hover, .preview-btn:hover {
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 95vw;
+  height: 95vh;
   max-width: 95%;
   max-height: 95%;
+}
+
+#modal-image-container {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
   overflow: hidden;
   cursor: grab;
   touch-action: none;
 }
 
-#modal-image-wrapper.is-grabbing {
+#modal-image-container.is-grabbing {
   cursor: grabbing;
 }
 
@@ -332,6 +345,7 @@ button:hover, .preview-btn:hover {
   max-width: 100%;
   max-height: 100%;
   margin: 0;
+  transform-origin: center center;
   transition: transform 0.1s ease-out;
   will-change: transform;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -99,51 +99,115 @@ document.addEventListener('DOMContentLoaded', function() {
   const modalCloseButton = document.getElementById('modal-close');
   const modalCounter = document.getElementById('modal-counter');
   const modalImageWrapper = document.getElementById('modal-image-wrapper');
+  const modalImageContainer = document.getElementById('modal-image-container');
 
   let activeImageList = [];
   let activeImageSource = '';
   let activeImageIndex = 0;
   let modalScale = 1;
-  const MODAL_MIN_SCALE = 1;
+  let modalMinScale = 1;
   const MODAL_MAX_SCALE = 4;
   let modalTranslateX = 0;
   let modalTranslateY = 0;
-  let isPanning = false;
+  const pointerPositions = new Map();
   let panPointerId = null;
+  let isPanning = false;
+  let pinchInitialDistance = 0;
+  let pinchInitialScale = 1;
   const lastPanPosition = { x: 0, y: 0 };
 
+  function clampScale(value) {
+    return Math.min(MODAL_MAX_SCALE, Math.max(modalMinScale, value));
+  }
+
   function setWrapperCursor(isGrabbing) {
-    if (!modalImageWrapper) return;
-    modalImageWrapper.classList.toggle('is-grabbing', Boolean(isGrabbing));
+    if (!modalImageContainer) return;
+    modalImageContainer.classList.toggle('is-grabbing', Boolean(isGrabbing));
   }
 
   function applyModalTransform() {
     if (!modalImg) return;
-    if (modalScale === 1 && modalTranslateX === 0 && modalTranslateY === 0) {
+    if (Math.abs(modalScale - 1) < 0.0001 && Math.abs(modalTranslateX) < 0.0001 && Math.abs(modalTranslateY) < 0.0001) {
       modalImg.style.transform = '';
     } else {
       modalImg.style.transform = `translate(${modalTranslateX}px, ${modalTranslateY}px) scale(${modalScale})`;
     }
   }
 
+  function clearPointerState() {
+    if (modalImageContainer && typeof modalImageContainer.releasePointerCapture === 'function') {
+      pointerPositions.forEach(function(_, pointerId) {
+        try {
+          modalImageContainer.releasePointerCapture(pointerId);
+        } catch (error) {
+          /* Ignore release errors */
+        }
+      });
+    }
+    pointerPositions.clear();
+    isPanning = false;
+    panPointerId = null;
+    pinchInitialDistance = 0;
+    pinchInitialScale = modalScale;
+    setWrapperCursor(false);
+  }
+
   function resetModalTransform() {
-    modalScale = 1;
+    clearPointerState();
+    if (!modalImg || !modalImageWrapper) {
+      modalScale = 1;
+      modalMinScale = 1;
+      modalTranslateX = 0;
+      modalTranslateY = 0;
+      applyModalTransform();
+      return;
+    }
+    const rect = modalImageWrapper.getBoundingClientRect();
+    const naturalWidth = modalImg.naturalWidth || 0;
+    const naturalHeight = modalImg.naturalHeight || 0;
+    if (rect.width > 0 && rect.height > 0 && naturalWidth > 0 && naturalHeight > 0) {
+      const scaleX = rect.width / naturalWidth;
+      const scaleY = rect.height / naturalHeight;
+      const containedScale = Math.min(scaleX, scaleY, 1);
+      modalMinScale = containedScale > 0 ? containedScale : 1;
+    } else {
+      modalMinScale = 1;
+    }
+    modalScale = modalMinScale;
     modalTranslateX = 0;
     modalTranslateY = 0;
-    isPanning = false;
-    if (panPointerId !== null && modalImageWrapper && typeof modalImageWrapper.releasePointerCapture === 'function') {
-      if (!modalImageWrapper.hasPointerCapture || modalImageWrapper.hasPointerCapture(panPointerId)) {
-        modalImageWrapper.releasePointerCapture(panPointerId);
-      }
-    }
-    panPointerId = null;
-    setWrapperCursor(false);
     applyModalTransform();
   }
 
   function updatePanPosition(event) {
     lastPanPosition.x = event.clientX;
     lastPanPosition.y = event.clientY;
+  }
+
+  function performZoom(clientX, clientY, targetScale) {
+    if (!modalImageContainer || !modalImg) {
+      return;
+    }
+    const rect = modalImageContainer.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) {
+      modalScale = clampScale(targetScale);
+      applyModalTransform();
+      return;
+    }
+    const clampedScale = clampScale(targetScale);
+    const offsetX = clientX - rect.left;
+    const offsetY = clientY - rect.top;
+    const currentScale = modalScale;
+    if (clampedScale === currentScale) {
+      applyModalTransform();
+      return;
+    }
+    const imageX = offsetX / currentScale - modalTranslateX;
+    const imageY = offsetY / currentScale - modalTranslateY;
+    modalScale = clampedScale;
+    modalTranslateX = offsetX / modalScale - imageX;
+    modalTranslateY = offsetY / modalScale - imageY;
+    applyModalTransform();
   }
 
   function updateModalCounter() {
@@ -235,62 +299,109 @@ document.addEventListener('DOMContentLoaded', function() {
     modalImg.addEventListener('load', resetModalTransform);
   }
 
-  if (modalImageWrapper) {
-    modalImageWrapper.addEventListener('wheel', function(event) {
+  if (modalImageContainer) {
+    modalImageContainer.addEventListener('wheel', function(event) {
       event.preventDefault();
-      const direction = event.deltaY < 0 ? 1 : -1;
-      const newScale = Math.min(MODAL_MAX_SCALE, Math.max(MODAL_MIN_SCALE, modalScale + direction * 0.1));
-      if (newScale !== modalScale) {
-        modalScale = parseFloat(newScale.toFixed(2));
-        applyModalTransform();
-      }
+      const zoomFactor = Math.exp(-event.deltaY / 300);
+      const newScale = modalScale * zoomFactor;
+      performZoom(event.clientX, event.clientY, newScale);
     }, { passive: false });
 
-    modalImageWrapper.addEventListener('pointerdown', function(event) {
-      panPointerId = event.pointerId;
-      isPanning = true;
-      setWrapperCursor(true);
-      updatePanPosition(event);
-      if (typeof modalImageWrapper.setPointerCapture === 'function') {
-        modalImageWrapper.setPointerCapture(panPointerId);
+    modalImageContainer.addEventListener('pointerdown', function(event) {
+      if (typeof modalImageContainer.setPointerCapture === 'function') {
+        modalImageContainer.setPointerCapture(event.pointerId);
+      }
+      pointerPositions.set(event.pointerId, { clientX: event.clientX, clientY: event.clientY });
+      if (pointerPositions.size === 1) {
+        panPointerId = event.pointerId;
+        isPanning = true;
+        setWrapperCursor(true);
+        updatePanPosition(event);
+      } else if (pointerPositions.size === 2) {
+        isPanning = false;
+        setWrapperCursor(false);
+        const points = Array.from(pointerPositions.values());
+        pinchInitialDistance = Math.hypot(points[0].clientX - points[1].clientX, points[0].clientY - points[1].clientY);
+        pinchInitialScale = modalScale;
       }
     });
 
-    modalImageWrapper.addEventListener('pointermove', function(event) {
-      if (!isPanning || event.pointerId !== panPointerId) {
+    modalImageContainer.addEventListener('pointermove', function(event) {
+      if (!pointerPositions.has(event.pointerId)) {
         return;
       }
-      const deltaX = event.clientX - lastPanPosition.x;
-      const deltaY = event.clientY - lastPanPosition.y;
-      modalTranslateX += deltaX;
-      modalTranslateY += deltaY;
-      updatePanPosition(event);
-      applyModalTransform();
+      pointerPositions.set(event.pointerId, { clientX: event.clientX, clientY: event.clientY });
+      if (pointerPositions.size >= 2) {
+        const points = Array.from(pointerPositions.values()).slice(0, 2);
+        const distance = Math.hypot(points[0].clientX - points[1].clientX, points[0].clientY - points[1].clientY);
+        if (pinchInitialDistance === 0) {
+          pinchInitialDistance = distance;
+          pinchInitialScale = modalScale;
+        }
+        if (distance > 0 && pinchInitialDistance > 0) {
+          const midpointX = (points[0].clientX + points[1].clientX) / 2;
+          const midpointY = (points[0].clientY + points[1].clientY) / 2;
+          const newScale = pinchInitialScale * (distance / pinchInitialDistance);
+          performZoom(midpointX, midpointY, newScale);
+        }
+      } else if (isPanning && event.pointerId === panPointerId) {
+        const deltaX = event.clientX - lastPanPosition.x;
+        const deltaY = event.clientY - lastPanPosition.y;
+        modalTranslateX += deltaX / modalScale;
+        modalTranslateY += deltaY / modalScale;
+        updatePanPosition(event);
+        applyModalTransform();
+      }
     });
 
-    function endPan(event) {
-      if (!isPanning || (event.pointerId !== panPointerId && panPointerId !== null)) {
-        return;
+    function handlePointerEnd(event) {
+      if (pointerPositions.has(event.pointerId)) {
+        pointerPositions.delete(event.pointerId);
       }
-      isPanning = false;
-      setWrapperCursor(false);
-      if (typeof modalImageWrapper.releasePointerCapture === 'function' && panPointerId !== null) {
-        if (!modalImageWrapper.hasPointerCapture || modalImageWrapper.hasPointerCapture(panPointerId)) {
-          modalImageWrapper.releasePointerCapture(panPointerId);
+      if (typeof modalImageContainer.releasePointerCapture === 'function') {
+        try {
+          modalImageContainer.releasePointerCapture(event.pointerId);
+        } catch (error) {
+          /* Ignore release errors */
         }
       }
-      panPointerId = null;
+      if (pointerPositions.size === 1) {
+        const remainingId = pointerPositions.keys().next().value;
+        const remainingPos = pointerPositions.get(remainingId);
+        if (remainingPos) {
+          panPointerId = remainingId;
+          isPanning = true;
+          setWrapperCursor(true);
+          lastPanPosition.x = remainingPos.clientX;
+          lastPanPosition.y = remainingPos.clientY;
+        }
+        pinchInitialDistance = 0;
+        pinchInitialScale = modalScale;
+      } else if (pointerPositions.size === 0) {
+        clearPointerState();
+      } else {
+        isPanning = false;
+        setWrapperCursor(false);
+        pinchInitialDistance = 0;
+        pinchInitialScale = modalScale;
+      }
     }
 
-    modalImageWrapper.addEventListener('pointerup', endPan);
-    modalImageWrapper.addEventListener('pointerleave', endPan);
-    modalImageWrapper.addEventListener('pointercancel', endPan);
+    modalImageContainer.addEventListener('pointerup', handlePointerEnd);
+    modalImageContainer.addEventListener('pointerleave', handlePointerEnd);
+    modalImageContainer.addEventListener('pointercancel', handlePointerEnd);
 
-    modalImageWrapper.addEventListener('dblclick', function(event) {
+    modalImageContainer.addEventListener('dblclick', function(event) {
       event.preventDefault();
       resetModalTransform();
     });
   }
+
+  window.addEventListener('resize', function() {
+    if (modal && modal.style.display === 'flex') {
+      resetModalTransform();
+    }
+  });
 
   const artworkThumbnails = document.querySelectorAll('.artwork-thumbnail');
   const artworkImages = Array.from(artworkThumbnails).map((thumb) => thumb.getAttribute('src') || thumb.src);


### PR DESCRIPTION
## Summary
- wrap the modal image in a dedicated container and prevent native dragging so transforms don't collide with controls
- style the modal viewport wrapper to constrain to the viewport, hide overflow, and use grab/grabbing cursors
- port pan/zoom logic to pointer, wheel, and touch interactions with contained scaling, reset, and responsive recalculation

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f40768fc832389665052205ddaff